### PR TITLE
Add postmortems section to master branch 

### DIFF
--- a/conduct.md
+++ b/conduct.md
@@ -25,14 +25,15 @@ insight in how to improve in future projects.
   * *Members shall*
     * Participate in the discussions in a respectful and courteous manner
     * Provide constructive criticism and propose solutions for issues faced
-    * Receive feedback and work on improving in the future
-    * Work together to fix any issues with the project after its launch 
+    * Receive feedback and work on improving in the future, criticism
+    is not personal
+    * Work together to fix any issues with the project after its launch
 
 * **Unacceptable Conduct (U):**
   * *Members shall not*
-    * Enter agreed upon rules
-    * Enter agreed upon rules
-    * Enter agreed upon rules
+    * Insult others while presenting criticism
+    * Blame other members for any issues with the final product
+    * Refuse to collaborate in fixing remaining issues
 
 * Conflicts
 * Infractions

--- a/conduct.md
+++ b/conduct.md
@@ -23,11 +23,13 @@ insight in how to improve in future projects.
 
 * **Acceptable Conduct (A):**
   * *Members shall*
+    * Create an agenda of things that need to be reviewed and fixed
     * Participate in the discussions in a respectful and courteous manner
     * Provide constructive criticism and propose solutions for issues faced
     * Receive feedback and work on improving in the future, criticism
     is not personal
     * Work together to fix any issues with the project after its launch
+
 
 * **Unacceptable Conduct (U):**
   * *Members shall not*

--- a/conduct.md
+++ b/conduct.md
@@ -13,7 +13,27 @@
 * Communication
 * Participation
 * Decisions
-* Postmortems
+
+## Postmortems
+
+Postmortems are great ways of looking at and analyzing the performance of the
+project after its launch. Through postmortems we can look at what was successful
+and what failed and needs improvement. These discussions also provide great
+insight in how to improve in future projects.
+
+* **Acceptable Conduct (A):**
+  * *Members shall*
+    * Participate in the discussions in a respectful and courteous manner
+    * Provide constructive criticism and propose solutions for issues faced
+    * Receive feedback and work on improving in the future
+    * Work together to fix any issues with the project after its launch 
+
+* **Unacceptable Conduct (U):**
+  * *Members shall not*
+    * Enter agreed upon rules
+    * Enter agreed upon rules
+    * Enter agreed upon rules
+
 * Conflicts
 * Infractions
 

--- a/conduct.md
+++ b/conduct.md
@@ -30,7 +30,6 @@ insight in how to improve in future projects.
     is not personal
     * Work together to fix any issues with the project after its launch
 
-
 * **Unacceptable Conduct (U):**
   * *Members shall not*
     * Insult others while presenting criticism

--- a/conduct.md
+++ b/conduct.md
@@ -21,8 +21,8 @@ project after its launch. Through postmortems we can look at what was successful
 and what failed and needs improvement. These discussions also provide great
 insight in how to improve in future projects.
 
-* **Acceptable Conduct (A):**
-  * *Members shall*
+* Acceptable Conduct (A):
+  * Members shall
     * Work as a team to create a postmortem plan to review and fix sections of
     the project
     * Come up with different approaches to solve issues with the project
@@ -32,8 +32,8 @@ insight in how to improve in future projects.
     * Receive feedback and discuss how it could be used to improve
     future projects and assignments
 
-* **Unacceptable Conduct (U):**
-  * *Members shall not*
+* Unacceptable Conduct (U):
+  * Members shall not
     * Insult others while presenting criticism
     * Blame other members for any issues with the final product
     * Refuse to collaborate in fixing remaining issues

--- a/conduct.md
+++ b/conduct.md
@@ -23,11 +23,14 @@ insight in how to improve in future projects.
 
 * **Acceptable Conduct (A):**
   * *Members shall*
-    * Create an agenda of things that need to be reviewed and fixed
+    * Work as a team to create a postmortem plan to review and fix sections of
+    the project
+    * Come up with different approaches to solve issues with the project
     * Participate in the discussions in a respectful and courteous manner
-    * Provide constructive criticism and propose solutions for issues faced
-    * Receive feedback and use it to improve future work
-    * Work together to fix any issues with the project after its launch
+    while adhering to the communications section of the code of conduct
+    * Provide constructive feedback and propose solutions for issues faced
+    * Receive feedback and discuss how it could be used to improve
+    future projects and assignments
 
 * **Unacceptable Conduct (U):**
   * *Members shall not*

--- a/conduct.md
+++ b/conduct.md
@@ -26,8 +26,7 @@ insight in how to improve in future projects.
     * Create an agenda of things that need to be reviewed and fixed
     * Participate in the discussions in a respectful and courteous manner
     * Provide constructive criticism and propose solutions for issues faced
-    * Receive feedback and work on improving in the future, criticism
-    is not personal
+    * Receive feedback and use it to improve future work
     * Work together to fix any issues with the project after its launch
 
 * **Unacceptable Conduct (U):**


### PR DESCRIPTION
The postmortems section of the code of conduct is complete, all checks pass in Travis with a green checkmark present. This pull-request would merger the team4-postmortems branch into the master branch. Please comment your suggestions, concerns, and feedback would be much appreciated. 